### PR TITLE
Add Flask-Moment to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask==0.10.1
 Flask-Bootstrap==3.1.1.2
 Flask-HTTPAuth==2.3.0
+Flask-Moment==0.4.0
 Flask-SQLAlchemy==2.0
 Flask-Script==2.0.5
 Flask-WTF==0.8.4


### PR DESCRIPTION
Hey.

I tried to deploy your project on my system.
I create virtual env, and install dependencies via:

```
pip install -r requirements.txt
```

Then i type python manage.py createall and get error:

```
python manage.py createall
Traceback (most recent call last):
  File "manage.py", line 4, in <module>
    from app import create_app, db
  File "/home/nless/Documents/projects/restful-todo/app/__init__.py", line 3, in <module>
    from flask.ext.moment import Moment
  File "/home/nless/.virtualenvs/vanilla-flask/lib/python2.7/site-packages/flask/exthook.py", line 87, in load_module
    raise ImportError('No module named %s' % fullname)
ImportError: No module named flask.ext.moment
```

So, fix in my patch.

My system:
- Fedora 20
- Python 2.7.5
